### PR TITLE
Move MapboxGeocoder.swift to master

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,6 @@ project 'Mapbox-iOS-Examples.xcodeproj'
 
 target 'Mapbox-iOS-Examples' do
   pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.4.0-beta.3/platform/ios/Mapbox-iOS-SDK.podspec'
-  pod 'MapboxGeocoder.swift', :git => 'https://github.com/mapbox/MapboxGeocoder.swift.git', :branch => 'swift3'
+  pod 'MapboxGeocoder.swift', :git => 'https://github.com/mapbox/MapboxGeocoder.swift.git', :commit => '6a4645bf8b19a1cb3703894141fc1bfe5d316d12'
   pod 'SwiftyJSON'
 end


### PR DESCRIPTION
Moved the MapboxGeocoder.swift pod off the swift3 branch, which is going away, per https://github.com/mapbox/MapboxGeocoder.swift/pull/57#issuecomment-280905054. Feel free to replace the commit with a newer one or the next release.